### PR TITLE
fix: :arrow_up: Bump minimum python version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,15 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python >=3.8
   run:
-    - python >=3.7
+    - python >=3.8
     - Ipython
     - kt-legacy
     - numpy


### PR DESCRIPTION
Bump minimum python version from 3.7 to 3.8

Fixes #24